### PR TITLE
Support for Ruby >= 2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.2.0'
+          - '3.2'
+          - '3.1'
+          - '3.0'
+          - '2.7'
 
     steps:
     - uses: actions/checkout@v3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-22
   x86_64-linux
 
 DEPENDENCIES

--- a/hercule-poro.gemspec
+++ b/hercule-poro.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary  = "Hercule::PORO helps give your Ruby POROs a healthy distance to their genius."
   spec.homepage = "https://github.com/kaspth/hercule-poro"
   spec.license  = "MIT"
-  spec.required_ruby_version = ">= 3.2.0"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.metadata["homepage_uri"]    = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage


### PR DESCRIPTION
Great gem! I love how *easy* it is to use a PORO with this gem.

I was able to get this running on Ruby 2.7 so I updated the spec and added the major versions between 2.7 - 3.2 to the CI matrix.